### PR TITLE
fix: scope npmrc for redhat packages

### DIFF
--- a/charts/backstage/templates/dynamic-plugins-npmrc.yaml
+++ b/charts/backstage/templates/dynamic-plugins-npmrc.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 metadata:
   name: dynamic-plugins-npmrc
 stringData:
-  .npmrc: registry=https://npm.registry.redhat.com
+  .npmrc: '@redhat:registry=https://npm.registry.redhat.com'
 type: Opaque


### PR DESCRIPTION
This ensures that packages with different scopes, e.g. "@backstage" can be installed from the regular npm registry. 